### PR TITLE
Add support for Cinnamon 2.2

### DIFF
--- a/opacify@anish.org/metadata.json
+++ b/opacify@anish.org/metadata.json
@@ -4,7 +4,8 @@
     "cinnamon-version": [
         "1.8", 
         "1.9", 
-        "2.0"
+        "2.0",
+        "2.2"
     ], 
     "name": "Opacify Windows",
     "url": "https://github.com/AnishN/Cinnamon-Extensions.git"


### PR DESCRIPTION
The new version of Cinnamon added the option to adjust the window opacity by scrolling on the titlebar, so it looks a bit odd if you grab the window while it is already semi-transparent. You may want to fix that a bit, but otherwise it seems to work fine in 2.2.
